### PR TITLE
Enter types into a symbol table

### DIFF
--- a/src/assert.ts
+++ b/src/assert.ts
@@ -1,0 +1,8 @@
+export function error(message: string): never {
+    throw Error(`Internal: ${message}`)
+}
+
+export function required<T>(value: T | undefined | null): T {
+    if (!value) error("Requirement failed")
+    return value
+}

--- a/src/ast.ts
+++ b/src/ast.ts
@@ -55,7 +55,9 @@ export type Element =
     InitalizerElement |
     ArrayInitalizerElement |
     NamedMemberInitializerElement |
-    NamedMemberElement |
+    LetDeclarationElement |
+    VarDeclarationElement |
+    ValDeclarationElement |
     ConstraintLetDeclarationElement |
     LambdaElement |
     LoopElement |
@@ -147,6 +149,18 @@ export interface NamedMemberElement extends NamedElement {
     readonly initializer: Optional<Element>
 }
 
+export interface LetDeclarationElement extends NamedMemberElement {
+    readonly kind: ElementKind.LetDeclaration
+}
+
+export interface VarDeclarationElement extends NamedMemberElement {
+    readonly kind: ElementKind.VarDeclaration
+}
+
+export interface ValDeclarationElement extends NamedMemberElement {
+    readonly kind: ElementKind.ValDeclaration
+}
+
 export interface ConstraintLetDeclarationElement extends NamedElement {
     readonly kind: ElementKind.ConstraintLetDeclaration
     readonly type: Element
@@ -202,7 +216,7 @@ export interface WhenElseClauseElement extends Location {
 
 export interface TypeLiteralElement extends Location {
     readonly kind: ElementKind.ValueTypeLiteral | ElementKind.MutableTypeLiteral
-    readonly typeParameters: Element[]
+    readonly typeParameters: TypeParameterElement[]
     readonly members: Element[]
     readonly constraint: Optional<Element>
 }
@@ -497,7 +511,7 @@ export class ElementBuilder {
         return { kind: ElementKind.NamedMemberInitializer, start: this.start, end: this.end, name, value }
     }
 
-    LetDeclaration(name: Name, type: Optional<Element>, initializer: Element): NamedMemberElement {
+    LetDeclaration(name: Name, type: Optional<Element>, initializer: Element): LetDeclarationElement {
         return { kind: ElementKind.LetDeclaration, start: this.start, end: this.end, name, type, initializer }
     }
 
@@ -505,11 +519,11 @@ export class ElementBuilder {
         return { kind: ElementKind.ConstraintLetDeclaration, start: this.start, end: this.end, name, type, initializer }
     }
 
-    VarDeclaration(name: Name, type: Optional<Element>, initializer: Optional<Element>): NamedMemberElement {
+    VarDeclaration(name: Name, type: Optional<Element>, initializer: Optional<Element>): VarDeclarationElement {
         return { kind: ElementKind.VarDeclaration, start: this.start, end: this.end, name, type, initializer }
     }
 
-    ValDeclaration(name: Name, type: Optional<Element>, initializer: Optional<Element>): NamedMemberElement {
+    ValDeclaration(name: Name, type: Optional<Element>, initializer: Optional<Element>): ValDeclarationElement {
         return { kind: ElementKind.ValDeclaration, start: this.start, end: this.end, name, type, initializer}
     }
 
@@ -549,11 +563,11 @@ export class ElementBuilder {
         return { kind: ElementKind.WhenElseClause, start: this.start, end: this.end, body }
     }
 
-    ValueTypeLiteral(typeParameters: Element[], members: Element[], constraint: Optional<Element>): TypeLiteralElement {
+    ValueTypeLiteral(typeParameters: TypeParameterElement[], members: Element[], constraint: Optional<Element>): TypeLiteralElement {
         return { kind: ElementKind.ValueTypeLiteral, start: this.start, end: this.end, typeParameters, members, constraint }
     }
 
-    MutableTypeLiteral(typeParameters: Element[], members: Element[], constraint: Optional<Element>): TypeLiteralElement {
+    MutableTypeLiteral(typeParameters: TypeParameterElement[], members: Element[], constraint: Optional<Element>): TypeLiteralElement {
         return { kind: ElementKind.MutableTypeLiteral, start: this.start, end: this.end, typeParameters, members, constraint }
     }
 

--- a/src/files.ts
+++ b/src/files.ts
@@ -18,6 +18,7 @@ export interface Position {
 export interface File {
     fileName: string
     size: number
+    location(start: number, end?: number): Location
     position(loc: Location): Position
 }
 
@@ -45,7 +46,7 @@ export class FileSet {
 
     file(loc: Location): File {
         const index = find(this.bases, loc.start)
-        return this.files[index] 
+        return this.files[index]
     }
 
     position(loc: Location): Position {
@@ -133,10 +134,10 @@ class PositionImpl implements Position {
     isValid: boolean
 
     constructor (
-        fileName: string, 
-        line: number, 
+        fileName: string,
+        line: number,
         lineStart: number,
-        column: number, 
+        column: number,
         length: number
     ) {
         this.fileName = fileName
@@ -155,7 +156,7 @@ class PositionImpl implements Position {
 }
 
 class FileImpl implements File {
-    fileName: string 
+    fileName: string
     size: number
     private base: number
     private lines: number[]
@@ -165,6 +166,13 @@ class FileImpl implements File {
         this.size = size
         this.base = base
         this.lines = lines
+    }
+
+    location(start: number, end?: number): Location {
+        const base = this.base
+        const startLocation = start + base
+        const endLocation = end ? end + base : startLocation
+        return { start: startLocation, end: endLocation }
     }
 
     position(loc: Location): Position {
@@ -177,7 +185,7 @@ class FileImpl implements File {
 
     private positionOf(start: number, end: number): Position {
         const line = this.lineOf(start)
-        if (line < 0) 
+        if (line < 0)
             return new PositionImpl(this.fileName, line, 0, 0, -1)
         const lineStart = this.lines[line]
         const column = (start - this.base) - lineStart + 1

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,7 +1,7 @@
 import {
     Optional, Name, ElementBuilder, BreakElement, Element, ContinueElement, LoopElement, WhenElement,
     OperatorPrecedenceRelation, OperatorPlacement, VocabularyOperatorPrecedence, SpreadElement,
-    OperatorAssociativity, ElementKind, childrenOf, NamedMemberElement, SelectionElement, InvokeMemberElement
+    OperatorAssociativity, ElementKind, childrenOf, NamedMemberElement, SelectionElement, InvokeMemberElement, TypeParameterElement
 } from './ast'
 import {
     Scanner
@@ -389,7 +389,7 @@ export function parse(scanner: Scanner, scope: VocabularyScope = new VocabularyS
         })
     }
 
-    function formalTypeParameter(): Element | null {
+    function formalTypeParameter(): TypeParameterElement | null {
         return ctx(() => {
             if (current != Token.Identifier) return null
             const nm = name()

--- a/src/types/context.ts
+++ b/src/types/context.ts
@@ -1,24 +1,43 @@
+import { typeBuilder, TypeBuilder, TypeKind, TypeSymbol } from ".";
 import { Element } from "../ast";
-import { File, FileSet } from "../files";
+import { File, FileSet, Location } from "../files";
 
-class Module {
+export interface Module {
     qualifiedName: string
     file: File
     elements: Element[]
-
-    constructor(qualifiedName: string, file: File, elements: Element[]) {
-        this.qualifiedName = qualifiedName
-        this.file = file
-        this.elements = elements
-    }
 }
 
-class TypeContext {
+export const enum DiagnosticKind {
+    Error,
+    Warning,
+}
+
+export interface Diagnostic {
+    kind: DiagnosticKind
+    location: Location
+    message: string
+    additional: Location[]
+}
+
+export class TypeContext {
     fileSet: FileSet
     modules: Module[]
-
+    globalSymbol: TypeSymbol = { name: "global", location: { start: -1, end: -1 } }
+    global = typeBuilder(this, TypeKind.Module, this.globalSymbol)
+    builders = new Map<TypeSymbol, TypeBuilder>()
+    diagnostics: Diagnostic[] = []
+ 
     constructor(fileSet: FileSet, modules: Module[]) {
         this.fileSet = fileSet
         this.modules = modules
+    }
+
+    report(kind: DiagnosticKind, location: Location, message: string, ...additional: Location[]) {
+        this.diagnostics.push({ kind, message, location, additional })
+    }
+
+    reportError(location: Location, message: string, ...additional: Location[]) {
+        this.diagnostics.push({ kind: DiagnosticKind.Error, message, location, additional })
     }
 }

--- a/src/types/enter.ts
+++ b/src/types/enter.ts
@@ -1,0 +1,245 @@
+import {
+    DefinitionKind,
+    Member,
+    MemberKind,
+    MemberSymbol,
+    TypeBuilder,
+    typeBuilder,
+    TypeDefinition,
+    TypeDefinitionKind,
+    TypeKind,
+    TypeParamater,
+    TypeParameterSymbol,
+    TypeSymbol,
+    ValueFieldMember
+} from ".";
+import { error, required } from "../assert";
+import {
+    ConstraintLiteralElement,
+    Element,
+    ElementKind,
+    LetDeclarationElement,
+    Name,
+    TypeLiteralElement,
+    TypeParameterElement,
+    ValDeclarationElement,
+    VarDeclarationElement
+} from "../ast";
+import {
+    Module,
+    TypeContext
+} from "./context";
+
+/**
+ * The first phase of type checking and binding.
+ * 
+ * Contruct type builders for all types and modules and create type symbols and module symbols.
+ * 
+ * @param context The typing context
+ */
+export function enterTypes(context: TypeContext) {
+    context.builders.set(context.global.symbol, context.global)
+
+    for (const module of context.modules) {
+        enterModule(module, context.global)
+    }
+
+    function enterModule(module: Module, container: TypeBuilder) {
+        let current = container
+        let moduleLocation = module.file.location(0)
+        for (const name of module.qualifiedName.split(".")) {
+            let moduleSymbol = current.members.find(name)
+            if (!moduleSymbol) {
+                const typeSymbol = { name, location: moduleLocation }
+                const builder = typeBuilder(context, TypeKind.Module, typeSymbol, current.symbol)
+                context.builders.set(typeSymbol, builder)
+                const typeDefinition: TypeDefinition = {
+                    kind: DefinitionKind.MutableType,
+                    type: typeSymbol
+                }
+                const definitionMember = {
+                    kind: MemberKind.Definition,
+                    definition: typeDefinition,
+                } as Member
+                const memberSymbol = { name, member: definitionMember, location: moduleLocation }
+                bind(definitionMember, memberSymbol)
+                current.addMember(memberSymbol)
+                current = builder
+            } else {
+                current = requireTypeBuilderOf(context, current, name, TypeKind.Module)
+            }
+        }
+        enterElements(module.elements, current)
+    }
+
+    function enterElements(elements: Element[], builder: TypeBuilder) {
+        for (let element of elements) {
+            enterElement(element, builder)
+        }
+    }
+
+    function enterElement(element: Element, builder: TypeBuilder) {
+        switch (element.kind) {
+            case ElementKind.LetDeclaration:
+                enterLetDeclaration(element, builder)
+                break
+            case ElementKind.ValDeclaration:
+                enterValDeclaration(element, builder)
+                break
+            case ElementKind.VarDeclaration:
+                enterVarDeclaration(element, builder)
+                break
+            case ElementKind.TypeParameter:
+                enterTypeParameter(element, builder)
+                break
+        }
+    }
+
+    function enterValDeclaration(
+        element: ValDeclarationElement,
+        builder: TypeBuilder
+    ) {
+        enterFieldDeclaration(MemberKind.ValueField, element, builder)
+    }
+
+    function enterVarDeclaration(
+        element: VarDeclarationElement,
+        builder: TypeBuilder
+    ) {
+        enterFieldDeclaration(MemberKind.MutableField, element, builder)
+    }
+
+    function enterFieldDeclaration(
+        kind: MemberKind,
+        element: VarDeclarationElement | ValDeclarationElement,
+        builder: TypeBuilder
+    ) {
+        const memberType = element.type
+        const name = memberType ? memberType.kind == ElementKind.Name ? memberType.text : "" : ""
+        const fieldTypeSymbol: TypeSymbol = {
+            name,
+            location: memberType || element
+        }
+        const member= {
+            kind,
+            type: fieldTypeSymbol
+        } as ValueFieldMember
+        const memberSymbol = {
+            name: element.name.text,
+            location: element.name,
+            member
+        }
+        builder.addMember(memberSymbol)
+    }
+
+    function enterLetDeclaration(
+        element: LetDeclarationElement,
+        builder: TypeBuilder
+    ) {
+        if (element.type) return
+        const initializer = element.initializer
+        if (!initializer) return
+        switch (initializer.kind) {
+            case ElementKind.Name:
+            case ElementKind.Selection:
+            case ElementKind.AndType:
+            case ElementKind.OrType:
+            case ElementKind.Call:
+            case ElementKind.Literal:
+            case ElementKind.Lambda:
+            case ElementKind.IntrinsicLambda:
+            case ElementKind.Loop:
+            case ElementKind.When:
+            case ElementKind.ValueLiteral:
+            case ElementKind.EntityLiteral:
+            case ElementKind.ValueArrayLiteral:
+            case ElementKind.EntityArrayLiteral: {
+                // Enter member symbols that will be filled in later
+                const memberSymbol = {
+                    name: element.name.text,
+                    location: element.name,
+                    member: undefined as any as Member
+                } as MemberSymbol
+                builder.addMember(memberSymbol)
+                break
+            }
+            case ElementKind.VocabularyLiteral: {
+                break
+            }
+            case ElementKind.ValueTypeLiteral:
+                enterTypeLiteral(builder, DefinitionKind.ValueType, element.name, initializer)
+                break
+            case ElementKind.MutableTypeLiteral:
+                enterTypeLiteral(builder, DefinitionKind.MutableType, element.name, initializer)
+                break
+            case ElementKind.ConstraintLiteral:
+                enterTypeLiteral(builder, DefinitionKind.Constraint, element.name, initializer)
+                break
+        }
+    }
+
+    function enterTypeLiteral(
+        builder: TypeBuilder,
+        kind: TypeDefinitionKind, 
+        name: Name, 
+        literal: TypeLiteralElement | ConstraintLiteralElement
+    ) {
+        const typeSymbol: TypeSymbol = {
+            name: name.text,
+            location: name
+        }
+        const definition: TypeDefinition = {
+            kind,
+            type: typeSymbol
+        }
+        const member = {
+            kind: MemberKind.Definition,
+            definition
+        } as Member
+        const memberSymbol: MemberSymbol = {
+            name: name.text,
+            location: name,
+            member
+        }
+        builder.addMember(memberSymbol)
+        const memberTypeBuilder = typeBuilder(context, TypeKind.Record, typeSymbol, builder.symbol)
+        context.builders.set(typeSymbol, memberTypeBuilder)
+
+        enterElements(literal.typeParameters, memberTypeBuilder)
+        enterElements(literal.members, memberTypeBuilder)
+    }
+
+    function enterTypeParameter(
+        element: TypeParameterElement,
+        builder: TypeBuilder
+    ) {
+        const typeParameter: TypeParamater = { constraints: undefined }
+        const typeParameterSymbol: TypeParameterSymbol = {
+            name: element.name.text,
+            location: element.name,
+            typeParameter
+        }
+        builder.addTypeParameter(typeParameterSymbol)
+    }
+
+    function bind<S, T extends { symbol: S }>(value: T, symbol: S) {
+        (value as any).symbol = symbol
+    }
+}
+
+function requireTypeBuilderOf(
+    context: TypeContext,
+    scope: TypeBuilder,
+    name: string,
+    kind: TypeKind
+): TypeBuilder {
+    const member = required(scope.members.find(name)).member
+    if (member.kind != MemberKind.Definition) error("Required member not found")
+    const definition = member.definition
+    if (definition.kind != DefinitionKind.MutableType) error("Required type definition")
+    const symbol =  definition.type
+    const builder = context.builders.get(symbol)
+    const found = required(builder)
+    if (found.kind != kind) error("Wrong type kind")
+    return found
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,14 +1,331 @@
-import { ElementKind } from "../ast";
+import { required } from '../assert'
+import { Element, Optional } from '../ast'
+import { Literal } from '../tokens'
+import { TypeContext } from './context'
+import { Symbol, Scope, ScopeBuilder, scopeBuilder } from './symbols'
+
+// Types
 
 export const enum TypeKind {
     Value,
     Record,
-    ArrayValue,
-    ArrayRecord,
     Reference,
-    Function
+    Function,
+    IntrinicFunction,
+    Constraint,
+    Module,
+    And,
+    Or,
 }
 
-export interface TypeDescription {
-    kind: TypeKind
+export interface TypeSymbol extends Symbol {
+    readonly type?: Type
+}
+
+export function canonicalSymbolOf(typeSym: TypeSymbol): TypeSymbol {
+    const type = typeSym.type
+    return type ? type.symbol : typeSym
+}
+
+interface BoundType extends Symbol {
+    readonly type: Type
+}
+
+type SimpleBound<T> = Exclude<T, BoundType> | BoundType
+
+export type Bound<T> = SimpleBound<T> | {
+    [P in keyof Exclude<T, BoundType>]: Bound<P>
+}
+
+export type Type =
+    RecordType |
+    ValueType |
+    ReferenceType |
+    FunctionType |
+    TypeConstraint |
+    AndType |
+    OrType |
+    ModuleType
+
+export interface TypeBase {
+    readonly kind: TypeKind
+    readonly symbol: TypeSymbol
+    readonly typeParameters: Scope<TypeParameterSymbol>
+    readonly container?: TypeSymbol
+}
+
+export interface TypeWithMembers extends TypeBase {
+    readonly members: Scope<MemberSymbol>
+    readonly signatures: Scope<SignatureSymbol>
+}
+
+export interface ValueType extends TypeWithMembers {
+    readonly kind: TypeKind.Value
+}
+
+export interface RecordType extends TypeWithMembers {
+    readonly kind: TypeKind.Record
+}
+
+export interface ReferenceType extends TypeBase {
+    readonly kind: TypeKind.Reference
+    readonly referant: TypeSymbol
+}
+
+export interface FunctionType extends TypeWithMembers {
+    readonly kind: TypeKind.Function
+}
+
+export interface IntrinsicFunctionType extends TypeWithMembers {
+    readonly kind: TypeKind.IntrinicFunction
+}
+
+export interface ModuleType extends TypeWithMembers {
+    readonly kind: TypeKind.Module
+}
+
+export interface TypeConstraint extends TypeBase {
+    readonly kind: TypeKind.Constraint
+    readonly type: TypeSymbol
+}
+
+export interface BinaryTypeOperator extends TypeBase {
+    readonly left: TypeSymbol
+    readonly right: TypeSymbol
+}
+
+export interface OrType extends TypeBase {
+    readonly kind: TypeKind.Or
+}
+
+export interface AndType extends TypeBase {
+    readonly kind: TypeKind.And
+}
+
+// TypeParameter
+
+export interface TypeParameterSymbol extends Symbol {
+    readonly typeParameter: TypeParamater
+}
+
+export interface TypeParamater {
+    readonly constraints: Optional<TypeSymbol>
+}
+
+// Members
+
+export const enum MemberKind {
+    ValueField,
+    MutableField,
+    Definition,
+    Alias,
+}
+
+export type Member =
+    ValueFieldMember |
+    MutableFieldMember |
+    DefinitionMember |
+    AliasMember
+
+export interface MemberSymbol extends Symbol {
+    readonly member: Member
+}
+
+export interface MemberBase {
+    readonly kind: MemberKind
+    readonly symbol: MemberSymbol
+}
+
+export interface ValueFieldMember extends MemberBase {
+    readonly kind: MemberKind.ValueField
+    readonly type: TypeSymbol
+}
+
+export interface MutableFieldMember extends MemberBase {
+    readonly kind: MemberKind.MutableField
+    readonly type: TypeSymbol
+}
+
+export interface DefinitionMember extends MemberBase {
+    readonly definition: Definition
+}
+
+export interface AliasMember extends MemberBase {
+    readonly kind: MemberKind.Alias
+    readonly original: MemberSymbol
+}
+
+// Definition
+
+export const enum DefinitionKind {
+    Constant,
+    Function,
+    ValueType,
+    MutableType,
+    Constraint
+}
+
+export type TypeDefinitionKind = DefinitionKind.MutableType | DefinitionKind.ValueType | DefinitionKind.Constraint
+
+export type Definition =
+    FunctionDefinition |
+    ConstantDefinition |
+    TypeDefinition
+
+export interface ConstantDefinition {
+    readonly kind: DefinitionKind.Constant
+    readonly literal: Literal
+    readonly value: any
+}
+
+export interface FunctionDefinition {
+    readonly kind: DefinitionKind.Function
+    readonly ast: Element
+}
+
+export interface TypeDefinition {
+    readonly kind: TypeDefinitionKind
+    readonly type: TypeSymbol
+}
+
+// Signatures
+
+export interface SignatureSymbol extends Symbol {
+    readonly signature: Signature
+}
+
+export interface Signature {
+    readonly parameter: Scope<ParameterSymbol>
+    readonly typeParameters: Scope<TypeParameterSymbol>
+    readonly result: TypeSymbol
+}
+
+export interface ParameterSymbol extends Symbol {
+    readonly parameter: Parameter
+}
+
+export const enum ParameterKind {
+    Named,
+    Block,
+    Spread,
+}
+
+type Parameter =
+    NamedParameter |
+    BlockParameter |
+    SpreadParameter
+
+export interface ParameterBase {
+    readonly kind: ParameterKind
+    readonly symbol: ParameterSymbol
+    readonly type: TypeSymbol
+}
+
+export interface NamedParameter extends ParameterBase {
+    readonly kind: ParameterKind.Named
+}
+
+export interface BlockParameter extends ParameterBase {
+    readonly kind: ParameterKind.Block
+}
+
+export interface SpreadParameter extends ParameterBase {
+    readonly kind: ParameterKind.Spread
+}
+
+export interface TypeBuilder extends  TypeBase, TypeWithMembers {
+    readonly kind: TypeKind
+    readonly symbol: TypeSymbol
+    readonly typeParameters: Scope<TypeParameterSymbol>
+    readonly container: TypeSymbol | undefined
+
+    addTypeParameter(parameter: TypeParameterSymbol): void
+    addMember(member: MemberSymbol): void
+    addSignature(signature: SignatureSymbol): void
+    build(): void
+}
+
+export function typeBuilder(
+    context: TypeContext,
+    kind: BuildableTypeKinds,
+    symbol: TypeSymbol,
+    container?: TypeSymbol
+): TypeBuilder {
+    return new TypeBuilderImpl(context, kind, symbol, container)
+}
+
+export type BuildableTypeKinds =
+    TypeKind.Record |
+    TypeKind.Value |
+    TypeKind.Module |
+    TypeKind.Function |
+    TypeKind.IntrinicFunction
+
+class TypeBuilderImpl implements TypeBuilder {
+    kind: BuildableTypeKinds
+    symbol: TypeSymbol
+    container: TypeSymbol | undefined
+    get typeParameters(): Scope<TypeParameterSymbol> { return this.typeParametersBuilder }
+    get members(): Scope<MemberSymbol> { return this.membersBuilder }
+    get signatures(): Scope<SignatureSymbol> { return this.signaturesBuilder }
+
+    private context: TypeContext
+    private typeParametersBuilder = scopeBuilder<TypeParameterSymbol>()
+    private membersBuilder = scopeBuilder<MemberSymbol>()
+    private signaturesBuilder = scopeBuilder<SignatureSymbol>()
+
+    constructor(
+        context: TypeContext,
+        kind: BuildableTypeKinds,
+        symbol: TypeSymbol,
+        container?: TypeSymbol
+    ) {
+        this.context = context
+        this.kind = kind
+        this.symbol = symbol
+        this.container = container
+    }
+
+    addTypeParameter(parameter: TypeParameterSymbol): boolean {
+        return this.enterSymbol(this.typeParametersBuilder, parameter)
+    }
+
+    addMember(member: MemberSymbol): boolean {
+        return this.enterSymbol(this.membersBuilder, member)
+    }
+
+    addSignature(signature: SignatureSymbol): boolean {
+        return this.enterSymbol(this.signaturesBuilder, signature)
+    }
+
+    build(): Type {
+        const type = {
+            kind: this.kind,
+            symbol: this.symbol,
+            typeParameters: this.typeParametersBuilder.build(),
+            members: this.membersBuilder.build(),
+            signatures: this.signaturesBuilder.build()
+        } as Type
+
+        bindType(this.symbol, type)
+        return type
+    }
+
+    private enterSymbol<S extends Symbol>(builder: ScopeBuilder<S>, symbol: S): boolean {
+        const other =
+            this.membersBuilder.find(symbol.name) ||
+            this.typeParametersBuilder.find(symbol.name) ||
+            this.signaturesBuilder.find(symbol.name)
+        if (other) {
+            this.context.reportError(symbol.location, "Duplicate symbol", other.location)
+            return false
+        } else {
+            required(builder.enter(symbol))
+        }
+        return true
+    }
+}
+
+function bindType(symbol: TypeSymbol, type: Type) {
+    (symbol as any).type = type
 }

--- a/src/types/symbols.spec.ts
+++ b/src/types/symbols.spec.ts
@@ -121,5 +121,5 @@ function s(...symbols: Symbol[]): Scope<Symbol> {
 }
 
 function sym(name: string): Symbol {
-    return { name }
+    return { name, location: { start: -1, end: -1 } }
 }

--- a/src/types/symbols.ts
+++ b/src/types/symbols.ts
@@ -1,5 +1,8 @@
+import { Location } from "../files"
+
 export interface Symbol {
     readonly name: string
+    readonly location: Location
 }
 
 export interface Scope<S extends Symbol> {
@@ -28,8 +31,16 @@ export function mergeScopes<S extends Symbol>(...scopes: Scope<S>[]): Scope<S> {
     switch (nonEmpty.length) {
         case 0: return emptyScope()
         case 1: return nonEmpty[0]
-        default: return new MergedScope(nonEmpty)
     }
+    const efffectiveScopes: Scope<S>[] = []
+    for (let scope of nonEmpty) {
+        if (scope instanceof MergedScope) {
+            efffectiveScopes.push(...scope.scopes)
+        } else {
+            efffectiveScopes.push(scope)
+        }
+    }
+    return new MergedScope(efffectiveScopes)
 }
 
 class EmptyScope implements Scope<any> {
@@ -108,7 +119,7 @@ class ScopeBuidlerImpl<S extends Symbol> extends ScopeImpl<S> implements ScopeBu
 }
 
 class MergedScope<S extends Symbol> implements Scope<S> {
-    private scopes: Scope<S>[]
+    scopes: Scope<S>[]
 
     constructor(scopes: Scope<S>[]) {
         this.scopes = scopes.reverse()


### PR DESCRIPTION
This adds the first phase of type checking. It add placeholders for
all globally reachable definitions so they can be reached during
the building phase.