### PR TITLE
Simplified the the language to be more IR like

### DIFF
--- a/examples/builtins.dg
+++ b/examples/builtins.dg
@@ -1,6 +1,6 @@
 let Operators = <|
   postfix operator (`++`, `--`, `?.`, `?`) right,
-  prefix operator (`+`, `-`, `--`, `++`) right,
+  prefix operator (`*`, `+`, `-`, `--`, `++`) right,
   infix operator (`as`, `as?`) left,
   infix operator (`*`, `/`, `%`) left,
   infix operator (`+`, `-`) left,
@@ -13,198 +13,289 @@ let Operators = <|
   infix operator `&&` left,
   infix operator `||` left,
   infix operator (`=`, `+=`, `*=`, `/=`, `%=`) right
+  prefix operator typeof right
+  prefix operator inferred right
 |>
 
 ...Operators
 
-let Inst = Uint16
-let Size = UInt64
+let Inst = typeof 0us
+let Size = typeof 0ul
+let Local = typeof 0ut
+
 let rt = <
+    let nop = 0us
+    let locals = <
+        let int32: Local = 0ut
+        let int64: Local = 1ut
+        let float32: Local = 2ut
+        let float64: Local = 3ut
+    >
     let bool = <
-        let size: Size = 1
-        let base: Inst = 0x0000
+        let size: Size = 1ul
+        let locals = [ locals.int32 ]
+        let base: Inst = 0x0100us
 
-        let load: Inst = base + 0
-        let store: Inst = base + 2
-        let pload: Inst = base + 3
-        let lload: Inst = base + 4
-        let lstore: Inst = base + 5
+        let load: Inst = base + 0us
+        let store: Inst = base + 2us
+        let pload: Inst = base + 3us
+        let lload: Inst = base + 4us
+        let lstore: Inst = base + 5us
 
-        let eq: Inst = base + 6
-        let neq: Inst = base + 7
-        let not: Inst = base + 8
+        let eq: Inst = base + 6us
+        let neq: Inst = base + 7us
+        let not: Inst = base + 8us
+
+        let toInt8: Inst = rt.nop
+        let toUint8: Inst = rt.nop
+        let toInt16: Inst = rt.nop
+        let toUInt16: Inst = rt.nop
+        let toInt32: Inst = rt.nop
+        let toUInt32: Inst = rt.nop
+        let toInt64: Inst = rt.int32.toInt64
+        let toUInt64: Inst = rt.int32.toUInt64
     >
     let int8 = <
-        let size: Size = 1
-        let base: Inst = 0x0100
+        let size: Size = 1ul
+        let locals = [ locals.int32 ]
+        let base: Inst = 0x0200us
 
-        let load: Inst = base + 0
-        let store: Inst = base + 1
-        let pload: Inst = base + 2
-        let lload: Inst = base + 3
-        let lstore: Inst = base + 4
+        let load: Inst = base + 0us
+        let store: Inst = base + 1us
+        let pload: Inst = base + 2us
+        let lload: Inst = base + 3us
+        let lstore: Inst = base + 4us
 
-        let add: Inst = base + 5
-        let sub: Inst = base + 6
-        let mult: Inst = base + 7
-        let div: Inst = base + 8
-        let mod: Inst = base + 9
-        let and: Inst = base + 10
-        let or: Inst = base + 11
-        let not: Inst = base + 12
-        let gt: Inst = base + 13
-        let lt: Inst = base + 14
-        let gte: Inst = base + 15
-        let lte: Inst = base + 16
-        let eq: Inst = base + 17
+        let add: Inst = base + 5us
+        let sub: Inst = base + 6us
+        let mult: Inst = base + 7us
+        let div: Inst = base + 8us
+        let mod: Inst = base + 9us
+        let and: Inst = base + 10us
+        let or: Inst = base + 11us
+        let not: Inst = base + 12us
+        let gt: Inst = base + 13us
+        let lt: Inst = base + 14us
+        let gte: Inst = base + 15us
+        let lte: Inst = base + 16us
+        let eq: Inst = base + 17us
+
+        let toUint8: Inst = rt.nop
+        let toInt16: Inst = rt.nop
+        let toUInt16: Inst = rt.nop
+        let toInt32: Inst = rt.nop
+        let toUInt32: Inst = rt.nop
+        let toInt64: Inst = rt.int32.toInt64
+        let toUInt64: Inst = rt.int32.toUInt64
     >
     let int16 = <
-        let size: Size = 2
-        let base: Inst = 0x0200
+        let size: Size = 2ul
+        let locals = [ locals.int32 ]
+        let base: Inst = 0x0300us
 
-        let load: Inst = base + 0
-        let store: Inst = base + 1
-        let pload: Inst = base + 2
-        let lload: Inst = base + 3
-        let lstore: Inst = base + 4
+        let load: Inst = base + 0us
+        let store: Inst = base + 1us
+        let pload: Inst = base + 2us
+        let lload: Inst = base + 3us
+        let lstore: Inst = base + 4us
 
-        let add: Inst = base + 5
-        let sub: Inst = base + 6
-        let mult: Inst = base + 7
-        let div: Inst = base + 8
-        let mod: Inst = base + 9
-        let and: Inst = base + 10
-        let or: Inst = base + 11
-        let not: Inst = base + 12
-        let gt: Inst = base + 13
-        let lt: Inst = base + 14
-        let gte: Inst = base + 15
-        let lte: Inst = base + 16
-        let eq: Inst = base + 17
+        let add: Inst = base + 5us
+        let sub: Inst = base + 6us
+        let mult: Inst = base + 7us
+        let div: Inst = base + 8us
+        let mod: Inst = base + 9us
+        let and: Inst = base + 10us
+        let or: Inst = base + 11us
+        let not: Inst = base + 12us
+        let gt: Inst = base + 13us
+        let lt: Inst = base + 14us
+        let gte: Inst = base + 15us
+        let lte: Inst = base + 16us
+        let eq: Inst = base + 17us
+
+        let toInt8: Inst = rt.int32.toInt8
+        let toUint8: Inst = rt.int32.toInt8
+        let toInt16: Inst = rt.nop
+        let toUInt16: Inst = rt.nop
+        let toInt32: Inst = rt.nop
+        let toUInt32: Inst = rt.nop
+        let toInt64: Inst = rt.int32.toInt64
+        let toUInt64: Inst = rt.int32.toUInt64
     >
     let int32 = <
-        let size: Size = 4
-        let base: Inst = 0x0300
+        let size: Size = 4ul
+        let locals = [ locals.int32 ]
+        let base: Inst = 0x0400us
 
-        let load: Inst = base + 0
-        let store: Inst = base + 1
-        let pload: Inst = base + 2
-        let lload: Inst = base + 3
-        let lstore: Inst = base + 4
+        let load: Inst = base + 0us
+        let store: Inst = base + 1us
+        let pload: Inst = base + 2us
+        let lload: Inst = base + 3us
+        let lstore: Inst = base + 4us
 
-        let add: Inst = base + 5
-        let sub: Inst = base + 6
-        let mult: Inst = base + 7
-        let div: Inst = base + 8
-        let mod: Inst = base + 9
-        let and: Inst = base + 10
-        let or: Inst = base + 11
-        let not: Inst = base + 12
-        let gt: Inst = base + 13
-        let lt: Inst = base + 14
-        let gte: Inst = base + 15
-        let lte: Inst = base + 16
-        let eq: Inst = base + 17
+        let add: Inst = base + 5us
+        let sub: Inst = base + 6us
+        let mult: Inst = base + 7us
+        let div: Inst = base + 8us
+        let mod: Inst = base + 9us
+        let and: Inst = base + 10us
+        let or: Inst = base + 11us
+        let not: Inst = base + 12us
+        let gt: Inst = base + 13us
+        let lt: Inst = base + 14us
+        let gte: Inst = base + 15us
+        let lte: Inst = base + 16us
+        let eq: Inst = base + 17us
+
+        let toInt8: Inst = base + 18us
+        let toUint8: Inst = base + 19us
+        let toInt16: Inst = base + 20us
+        let toUInt16: Inst = base + 21us
+        let toInt32: Inst = rt.nop
+        let toUInt32: Inst = rt.nop
+        let toInt64: Inst = base + 22us
+        let toUInt64: Inst = base + 23us
     >
     let int64 = <
-        let size: Size = 8
-        let base: Inst = 0x0400
+        let size: Size = 8ul
+        let locals = [ locals.int64 ]
+        let base: Inst = 0x0500u
 
-        let load: Inst = base + 0
-        let store: Inst = base + 1
-        let pload: Inst = base + 2
-        let lload: Inst = base + 3
-        let lstore: Inst = base + 4
+        let load: Inst = base + 0us
+        let store: Inst = base + 1us
+        let pload: Inst = base + 2us
+        let lload: Inst = base + 3us
+        let lstore: Inst = base + 4us
 
-        let add: Inst = base + 5
-        let sub: Inst = base + 6
-        let mult: Inst = base + 7
-        let div: Inst = base + 8
-        let mod: Inst = base + 9
-        let and: Inst = base + 10
-        let or: Inst = base + 11
-        let not: Inst = base + 12
-        let gt: Inst = base + 13
-        let lt: Inst = base + 14
-        let gte: Inst = base + 15
-        let lte: Inst = base + 16
-        let eq: Inst = base + 17
+        let add: Inst = base + 5us
+        let sub: Inst = base + 6us
+        let mult: Inst = base + 7us
+        let div: Inst = base + 8us
+        let mod: Inst = base + 9us
+        let and: Inst = base + 10us
+        let or: Inst = base + 11us
+        let not: Inst = base + 12us
+        let gt: Inst = base + 13us
+        let lt: Inst = base + 14us
+        let gte: Inst = base + 15us
+        let lte: Inst = base + 16us
+        let eq: Inst = base + 17us
+
+        let toInt8: Inst = base + 18us
+        let toUint8: Inst = base + 19us
+        let toInt16: Inst = base + 20us
+        let toUInt16: Inst = base + 21us
+        let toInt32: Inst = base + 22us
+        let toUInt32: Inst = base + 23us
+        let toInt64: Inst = rt.nop
+        let toUInt64: Inst = rt.nop
     >
     let uint8 = <
-        let size: Size = 1
-        let base: Inst = 0x0500
+        let size: Size = 1ul
+        let locals = [ locals.int32 ]
+        let base: Inst = 0x0600us
 
-        let load: Inst = base + 0
-        let store: Inst = base + 1
-        let pload: Inst = base + 2
-        let lload: Inst = base + 3
-        let lstore: Inst = base + 4
+        let load: Inst = base + 0us
+        let store: Inst = base + 1us
+        let pload: Inst = base + 2us
+        let lload: Inst = base + 3us
+        let lstore: Inst = base + 4us
 
-        let add: Inst = base + 5
-        let sub: Inst = base + 6
-        let mult: Inst = base + 7
-        let div: Inst = base + 8
-        let mod: Inst = base + 9
-        let and: Inst = base + 10
-        let or: Inst = base + 11
-        let not: Inst = base + 12
-        let gt: Inst = base + 13
-        let lt: Inst = base + 14
-        let gte: Inst = base + 15
-        let lte: Inst = base + 16
-        let eq: Inst = base + 17
+        let add: Inst = base + 5us
+        let sub: Inst = base + 6us
+        let mult: Inst = base + 7us
+        let div: Inst = base + 8us
+        let mod: Inst = base + 9us
+        let and: Inst = base + 10us
+        let or: Inst = base + 11us
+        let not: Inst = base + 12us
+        let gt: Inst = base + 13us
+        let lt: Inst = base + 14us
+        let gte: Inst = base + 15us
+        let lte: Inst = base + 16us
+        let eq: Inst = base + 17us
+
+        let toInt8: Inst = rt.nop
+        let toUint8: Inst = rt.nop
+        let toInt16: Inst = rt.nop
+        let toUInt16: Inst = rt.nop
+        let toInt32: Inst = rt.nop
+        let toUInt32: Inst = rt.nop
+        let toInt64: Inst = rt.int32.toInt64
+        let toUInt64: Inst = rt.int32.toUInt64
     >
     let uint16 = <
-        let size: Size = 2
-        let base: Inst = 0x0600
+        let size: Size = 2ul
+        let locals = [ locals.int32 ]
+        let base: Inst = 0x0700us
 
-        let load: Inst = base + 0
-        let store: Inst = base + 1
-        let pload: Inst = base + 2
-        let lload: Inst = base + 3
-        let lstore: Inst = base + 4
+        let load: Inst = base + 0us
+        let store: Inst = base + 1us
+        let pload: Inst = base + 2us
+        let lload: Inst = base + 3us
+        let lstore: Inst = base + 4us
 
-        let add: Inst = base + 5
-        let sub: Inst = base + 6
-        let mult: Inst = base + 7
-        let div: Inst = base + 8
-        let mod: Inst = base + 9
-        let and: Inst = base + 10
-        let or: Inst = base + 11
-        let not: Inst = base + 12
-        let gt: Inst = base + 13
-        let lt: Inst = base + 14
-        let gte: Inst = base + 15
-        let lte: Inst = base + 16
-        let eq: Inst = base + 17
+        let add: Inst = base + 5us
+        let sub: Inst = base + 6us
+        let mult: Inst = base + 7us
+        let div: Inst = base + 8us
+        let mod: Inst = base + 9us
+        let and: Inst = base + 10us
+        let or: Inst = base + 11us
+        let not: Inst = base + 12us
+        let gt: Inst = base + 13us
+        let lt: Inst = base + 14us
+        let gte: Inst = base + 15us
+        let lte: Inst = base + 16us
+        let eq: Inst = base + 17us
+
+        let toInt8: Inst = rt.int32.toInt8
+        let toUint8: Inst = rt.int32.toUInt8
+        let toInt16: Inst = rt.nop
+        let toUInt16: Inst = rt.nop
+        let toInt32: Inst = rt.nop
+        let toUInt32: Inst = rt.nop
+        let toInt64: Inst = rt.int32.toInt64
+        let toUInt64: Inst = rt.int32.toUInt64
     >
     let uint32 = <
-        let size: Size = 4
-        let base: Inst = 0x0700
+        let size: Size = 4ul
+        let locals = [ locals.int32 ]
+        let base: Inst = 0x0800us
 
-        let load: Inst = base + 0
-        let store: Inst = base + 1
-        let pload: Inst = base + 2
-        let lload: Inst = base + 3
-        let lstore: Inst = base + 4
+        let load: Inst = base + 0us
+        let store: Inst = base + 1us
+        let pload: Inst = base + 2us
+        let lload: Inst = base + 3us
+        let lstore: Inst = base + 4us
 
-        let add: Inst = base + 5
-        let sub: Inst = base + 6
-        let mult: Inst = base + 7
-        let div: Inst = base + 8
-        let mod: Inst = base + 9
-        let and: Inst = base + 10
-        let or: Inst = base + 11
-        let not: Inst = base + 12
-        let gt: Inst = base + 13
-        let lt: Inst = base + 14
-        let gte: Inst = base + 15
-        let lte: Inst = base + 16
-        let eq: Inst = base + 17
+        let add: Inst = base + 5us
+        let sub: Inst = base + 6us
+        let mult: Inst = base + 7us
+        let div: Inst = base + 8us
+        let mod: Inst = base + 9us
+        let and: Inst = base + 10us
+        let or: Inst = base + 11us
+        let not: Inst = base + 12us
+        let gt: Inst = base + 13us
+        let lt: Inst = base + 14us
+        let gte: Inst = base + 15us
+        let lte: Inst = base + 16us
+        let eq: Inst = base + 17us
+
+        let toInt8: Inst = rt.int32.toInt8
+        let toUint8: Inst = rt.int32.toUInt8
+        let toInt16: Inst = rt.int32.toInt16
+        let toUInt16: Inst = rt.int32.toUInt16
+        let toInt32: Inst = rt.nop
+        let toUInt32: Inst = rt.nop
+        let toInt64: Inst = rt.int32.toInt64
+        let toUInt64: Inst = rt.int32.toUInt64
     >
     let int64 = <
         let size: Size = 8
-        let base: Inst = 0x0800
+        let locals = [ locals.int64 ]
+        let base: Inst = 0x0900
         let load: Inst = base + 0
         let store: Inst = base + 1
         let pload: Inst = base + 2
@@ -224,81 +315,81 @@ let rt = <
         let gte: Inst = base + 15
         let lte: Inst = base + 16
         let eq: Inst = base + 17
+
+        let toInt8: Inst = rt.int64.toInt8
+        let toUint8: Inst = rt.int64.toUInt8
+        let toInt16: Inst = rt.int64.toInt16
+        let toUInt16: Inst = rt.int64.toUInt16
+        let toInt32: Inst = rt.int64.toInt32
+        let toUInt32: Inst = rt.int64.toUInt32
+        let toInt64: Inst = rt.int64.toInt64
+        let toUInt64: Inst = rt.int64.toUInt64
     >
     let float32 = <
         let size: Size = 4
-        let base: Inst = 0x0900
+        let locals = [ locals.float32 ]
+        let base: Inst = 0x0A00us
 
-        let load: Inst = base + 0
-        let store: Inst = base + 1
-        let pload: Inst = base + 2
-        let lload: Inst = base + 3
-        let lstore: Inst = base + 4
+        let load: Inst = base + 0us
+        let store: Inst = base + 1us
+        let pload: Inst = base + 2us
+        let lload: Inst = base + 3us
+        let lstore: Inst = base + 4us
 
-        let add: Inst = base + 5
-        let sub: Inst = base + 6
-        let mult: Inst = base + 7
-        let div: Inst = base + 8
+        let add: Inst = base + 5us
+        let sub: Inst = base + 6us
+        let mult: Inst = base + 7us
+        let div: Inst = base + 8us
 
-        let gt: Inst = base + 13
-        let lt: Inst = base + 14
-        let gte: Inst = base + 15
-        let lte: Inst = base + 16
-        let eq: Inst = base + 17
+        let gt: Inst = base + 13us
+        let lt: Inst = base + 14us
+        let gte: Inst = base + 15us
+        let lte: Inst = base + 16us
+        let eq: Inst = base + 17us
+
+        let floor: Inst = base + 18us
     >
     let float64 = <
         let size: Size = 4
-        let base: Inst = 0x0A00
-        let load: Inst = base + 0
-        let store: Inst = base + 1
-        let pload: Inst = base + 2
-        let lload: Inst = base + 3
-        let lstore: Inst = base + 4
+        let locals = [ locals.float64 ]
+        let base: Inst = 0x0B00us
+        let load: Inst = base + 0us
+        let store: Inst = base + 1us
+        let pload: Inst = base + 2us
+        let lload: Inst = base + 3us
+        let lstore: Inst = base + 4us
 
-        let add: Inst = base + 5
-        let sub: Inst = base + 6
-        let mult: Inst = base + 7
-        let div: Inst = base + 8
+        let add: Inst = base + 5us
+        let sub: Inst = base + 6us
+        let mult: Inst = base + 7us
+        let div: Inst = base + 8us
 
-        let gt: Inst = base + 13
-        let lt: Inst = base + 14
-        let gte: Inst = base + 15
-        let lte: Inst = base + 16
-        let eq: Inst = base + 17
+        let gt: Inst = base + 13us
+        let lt: Inst = base + 14us
+        let gte: Inst = base + 15us
+        let lte: Inst = base + 16us
+        let eq: Inst = base + 17us
     >
 >
 
-let SizedInstructions = <*
-    let size: Size
-*>
-
-let InternalSized = <
-    Instructions: SizedInstructions
-->
-    let `@size`: Size = Instrucitons.size
->
-
 let Address = UInt32
-let ParameterIndex = UInt8
+let Offset = UInt32
 let LocalIndex = UInt8
+let SlotIndex = UInt16
 
 let Locatable = <*
-    let `@load.global`: < { address: Address }: This >
-    let `@store.global`: < { this: This, address: Address } >
-    let `@load.param`: < { parameter: ParameterIndex }: This >
-    let `@load.local`: < { local: LocalIndex }: This >
-    let `@store.local`: < { this: This, local: LocalIndex } >
+    let `@size`: Size
+    let `@locals`: Local[]
+    let `@load.global`: {! address: Address !}: This
+    let `@store.global`: {! this: This, address: Address !}
+    let `@load.param`: {! index: LocalIndex !}: This
+    let `@load.local`: {! index: LocalIndex !}: This
+    let `@store.local`: {! this: This, index: LocalIndex !}
 *>
-
-let Defaultable = <*
-    let `@default`: This
-*>
-
-let Default = < value: This ->
-    let `@default`: This = value
->
 
 let LocationInstructions = <*
+    let size: Size
+    let locals: Local[]
     let load: Inst
     let store: Inst
     let pload: Inst
@@ -306,19 +397,108 @@ let LocationInstructions = <*
     let lstore: Inst
 *>
 
-let InternalLocation = <
+let LocatableByInstructions = <
     Instructions: LocationInstructions
 ->
-    let `@load.global`: < { address: Address }: This > = {! address, Instructions.load !}
-    let `@store.global`: < { this: This, address: Address } > = {! this, address, Instructions.store !}
-    let `@load.param`: < { parameter: ParameterIndex }: This > = {! this, Instructions.pload !}
-    let `@load.local`: < { local: LocalIndex }: This > = {! local, Instructions.lload !}
-    let `@store.local`: < { this: This, local: LocalIndex } > = {! this, local, Instructions.lstore !}
-> : Locatable
+    let `@size` = Instructions.size
+    let `@locals` = Instructions.locals
+    let `@load.global`: {! address: Address !} = {! Instructions.load !}
+    let `@store.global`: {! this: This, address: Address !} = {! Instructions.store !}
+    let `@load.param`: {! index: LocalIndex !} = {! Instructions.pload !}
+    let `@load.local`: {! index: LocalIndex !} = {! Instructions.lload !}
+    let `@store.local`: {! this: This, index: LocalIndex !} = {! Instructions.lstore !}
+>: Locatable
+
+let Location = <*
+    Type: Locatable
+->
+    let `*`: {! this: This !}: Type
+    let `=`: {! value: Type, this: This !}
+    let `@select`: {! Selected: Field<:Type> -> !}: Location<:Type>
+*>
+
+let LocalSlot = <
+    Type: Locatable
+    symbol: Symbol = <$ Type.`@locals` $>
+->
+    let `*`: {! type: This !}: Type = {! index, Type.`@load.local` !}
+    let `=`: {! value: Type, this: This !} = {! index, Type.`@store.local` !}
+    let `@select`: {! Selected: Field<:Type> -> !}: Location<:Type> = {! !}: LocalSlot<:Type, :symbol>
+>: Location<:Type>
+
+let ParameterSlot = <
+    Type: Locatable
+    symbol: Symbol = <$ Type.`@locals` $>
+->
+    let `*`: {! this: This !}: Type = {! index, Type.`@load.param` !}
+    let `@select`: {! Selected: Field<:Type> -> !}: Location<:Type> = {! !}: ParameterSlot<:Type, :symbol>
+>: Location<:Type>
+
+let GlobalSlot = <
+    Type: Locatable
+    symbol: Symbol = <$ Type.`@size` $>
+->
+    let `*`: {! this: This !}: Type = {! symbol.address, Type.`@load.global` !}
+    let `=`: {! value: Type, this: This !} = {! symbol.address, Type.`@store.global` !}
+    let `@select`: {! Selected: Field<:Type> -> !}: Location<:Type> = {! !}: GlobalSlot<:Type, :symbol>
+>: Location<:Type>
+
+let HeapSlot = <
+    Type: Locatable
+->
+    let `@size` = Address.`@size`
+    let `@locals` = Address.`@locals`
+    let `@load.global`: {! address: Address !}: This = {! Address.`@load.global` !}
+    let `@store.global`: {! this: This, address: Address !} = {! Address.`@store.global` !}
+    let `@load.param`: {! index: LocalIndex !}: This = {! Address.`@load.param` !}
+    let `@load.local`: {! index: LocalIndex !}: This = {! Address.`@load.local` !}
+    let `@store.local`: {! this: This, index: LocalIndex !} = {! Address.`@store.local` !}
+    let address = FieldSlot<Type: Address>
+
+    let `@ctor`: {
+        this: Location<Type: This>
+        address: ParameterSlot<Type: Address>
+    } = {
+        this.`@select`(:address) = *address
+    }
+
+    let `*`: {! this: This !}: Type = {! Type.`@load.global` !}
+    let `=`: {! value: Type, this: This !} = {! Type.`@store.global` !}
+
+    let `@select`: {! Selected: Field<Type: inferred DataType> -> !}: Location<Type: DataType> = {
+        return [<HeapSlot<Type: DataType>> address: *addess + Select.offset]
+    }
+    let `@index`: { DataType: Locatable -> index: Offset }: Location<:DataType> = {
+        return [<HeapSlot<Type: DataType>> address: *address + index * DataType.`@size`]
+    }
+>: Locatable & Location<:Type>
+
+let Field = <*
+    Type: Locatable
+->
+    let index: LocalIndex
+    let offset: Offset
+*>
+
+let FieldSlot = <
+    Type: Locatable
+    symbol: Symbol = <$ Type.`@size` $>
+->
+    let index = index
+    let offset = offset
+>: Field<:Type>
+
 
 let Equatable = <*
-    let `==`: < { this: This, other: This }: Boolean >
-    let `!=`: < { this: This, other: This }: Boolean >
+    ...Locatable
+    let `==`: {
+        this: ParameterSlot<Type: This>,
+        other: ParameterSlot<Type: This>
+    }: Boolean
+    let `!=`: {
+        this: ParameterSlot<Type: This>,
+        other: ParameterSlot<Type: This>
+    }: Boolean
 *>
 
 let EqualityInstructions = <*
@@ -326,19 +506,27 @@ let EqualityInstructions = <*
     let neq: Inst
 *>
 
-let InternalEquatable = <
+let BinaryFunction = {
+    Type: type
+    Result: type
+->
+    this: ParameterSlot<:Type>,
+    other: ParameterSlot<:Type>
+}: Result
+
+let EquatableByInstructions = <
     Instructions: EqualityInstructions
 ->
-    let `==`: < { this: This, other: This }: Boolean > = {! this, other, Instructions.eq !}
-    let `!=`: < { this: This, other: This }: Boolean > = {! this, other, Instructions.neq !}
+    let `==`: BinaryFunction<Type: This, Result: Boolean> = {! *this, *other, Instructions.eq !}
+    let `!=`: BinaryFunction<Type: This, Result: Boolean> = {! *this, *other, Instructions.neq !}
 > : Equatable
 
 let Comparable = <*
     ...Equatable
-    let `>`: < { this: This, other: This }: Boolean >
-    let `<`: < { this: This, other: This }: Boolean >
-    let `>=`: < { this: This, other: This }: Boolean >
-    let `<=`: < { this: This, other: This }: Boolean >
+    let `>`: BinaryFunction<Type: This, Result: Boolean>
+    let `<`: BinaryFunction<Type: This, Result: Boolean>
+    let `>=`: BinaryFunction<Type: This, Result: Boolean>
+    let `<=`: BinaryFunction<Type: This, Result: Boolean>
 *>
 
 let ComparableInstructions = <*
@@ -350,14 +538,14 @@ let ComparableInstructions = <*
     let eq: Int
 *>
 
-let InternalComparable = <
+let ComparableByInstructions = <
     Instructions: ComparableInstructions
 ->
     ...InternalEquatable<:Instructions>
-    let `>`: < { this: This, other: This }: Boolean > = {! this, other, Instructions.gt !}
-    let `<`: < { this: This, other: This }: Boolean > = {! this, other, Instructions.lt !}
-    let `>=`: < { this: This, other: This }: Boolean > = {! this, other, Instructions.gte !}
-    let `<=`: < { this: This, other: This }: Boolean > = {! this, other, Instructions.lte !}
+    let `>`: BinaryFunction<Type: This, Result: Boolean> = {! *this, *other, Instructions.gt !}
+    let `<`: BinaryFunction<Type: This, Result: Boolean> = {! *this, *other, Instructions.lt !}
+    let `>=`: BinaryFunction<Type: This, Result: Boolean> = {! *this, *other, Instructions.gte !}
+    let `<=`: BinaryFunction<Type: This, Result: Boolean> = {! *this, *other, Instructions.lte !}
 > : Comparable
 
 let NumericInstructions = <*
@@ -367,14 +555,13 @@ let NumericInstructions = <*
     let div: Inst
 *>
 
-let InternalNumeric = <
-    T: type
+let NumericByInstructions = <
     Instructions: NumericInstructions
 ->
-    let `+`: < { this: T, other: T }: T > = {! this, other, Instructions.add !}
-    let `-`: < { this: T, other: T }: T > = {! this, other, Instructions.sub !}
-    let `*`: < { this: T, other: T }: T > = {! this, other, Instructions.mult !}
-    let `/`: < { this: T, other: T }: T > = {! this, other, Instructions.div !}
+    let `+`: BinaryFunction<Type: This, Result: This> = {! *this, *other, Instructions.add !}
+    let `-`: BinaryFunction<Type: This, Result: This> = {! *this, *other, Instructions.sub !}
+    let `*`: BinaryFunction<Type: This, Result: This> = {! *this, *other, Instructions.mult !}
+    let `/`: BinaryFunction<Type: This, Result: This> = {! *this, *other, Instructions.div !}
 >
 
 let BitwiseInstructions = <*
@@ -383,17 +570,28 @@ let BitwiseInstructions = <*
     let not: Inst
 *>
 
-let InternalBitwise = <
-    T: type
+let BitwiseByInstructions = <
     Instructions: BitwiseInstructions
 ->
-    let `|`: < { this: T, other: T }: T > = {! this, other, Instructions.or !}
-    let `&`: < { this: T, other: T }: T > = {! this, other, Instructions.and !}
-    let `^`: < { this: T, other: T }: T > = {! this, other, Instructions.xor !}
-    let shl: < { this: T, other: Int }: T > = {! this, other, Instructions.shl !}
-    let shr: < { this: T, other: Int }: T > = {! this, other, Instructions.shr !}
-    let ror: < { this: T, other: Int }: T > = {! this, other, Instructions.ror !}
-    let rol: < { this: T, other: Int }: T > = {! this, other, Instructions.rol !}
+    let `|`: BinaryFunction<Type: This, Result: This> = {! *this, *other, Instructions.or !}
+    let `&`: BinaryFunction<Type: This, Result: This> = {! *this, *other, Instructions.and !}
+    let `^`: BinaryFunction<Type: This, Result: This> = {! *this, *other, Instructions.xor !}
+    let shl: {
+        this: ParameterSlot<Type: This>,
+        other: ParameterSlot<Type: Int>
+    }: This = {! *this, *other, Instructions.shl !}
+    let shr: {
+        this: ParameterSlot<Type: This>,
+        other: ParameterSlot<Type: Int>
+    }: This  = {! *this, *other, Instructions.shr !}
+    let ror: {
+        this: ParameterSlot<Type: This>,
+        other: ParameterSlot<Type: Int>
+    }: This  = {! *this, *other, Instructions.ror !}
+    let rol: {
+        this: ParameterSlot<Type: This>,
+        other: ParameterSlot<Type: Int>
+    }: This  = {! *this, *other, Instructions.rol !}
 >
 
 let IntegerInstructions = <*
@@ -403,193 +601,96 @@ let IntegerInstructions = <*
     let mod: Inst
 *>
 
-let InternalInteger = <
-    T: type
+let IntegerByInstructions = <
     Instructions: IntegerInstructions
 ->
-    ...InternalSized<:Instructions>
-    ...InternalLocation<:T, :Instructions>
-    ...InternalComparable<:T, :Instructions>
-    ...InternalNumeric<:T, :Instructions>
-    ...InternalBitwise<:T, :Instructions>
-    let `%`: < { this: T, other: T }: T > = {! this, other, Instructions.mod !}
+    ...LocationableByInstructions<:Instructions>
+    ...ComparableByInstructions<:Instructions>
+    ...NumericByInstructions<:Instructions>
+    ...BitwiseByInstructions<:Instructions>
+    let `%`: BinaryFunction<Type: This, Result: This> = {! *this, *other, Instructions.mod !}
 >
 
-let To64Instructions = <*
-    let to64: Inst
+let ConversionInstructions = <*
+    let toInt8: Inst
+    let toUInt8: Inst
+    let toInt16: Inst
+    let toUInt16: Inst
+    let toInt32: Inst
+    let toUInt32: Inst
+    let toInt64: Inst
+    let toUInt64: Inst
 *>
 
-let InternalToInt64 = <
-    T: type
-    Instructions: To64Instructions
+let ConversionFunction = { Type, Result -> this: ParameterSlot<:Type> }: Result
+
+let IntegerConversionByInstructions = <
+    Instructions: ConversionInstructions
 ->
-    let toInt64: < { this: T }: Int64 > = {! this, Instructions.to64 !}
->
-
-let InternalToUInt64 = <
-    T: type
-    Instructions: To64Instructions
-->
-    let toInt64: < { this: T }: UInt64 > = {! this, Instructions.to64 !}
->
-
-let To32Instructions = <*
-    let to32: Inst
-*>
-
-let InternalToInt32 = <
-    T: type
-    Instructions: To32Instructions
-->
-    let toInt32: < { this: T }: Int32 > = {! this, Instructions.to32 !}
-    let toInt: < { this: T }: Int > = {! this, Instructions.to32 !}
->
-
-let InternalToUInt32 = <
-    T: type
-    Instrutions: To32Instructions
-->
-    let toUInt32: < { this: T }: UInt32 > = {! this, Instruction.to32 !}
->
-
-let To16Instructions = <*
-    let to16: Inst
-*>
-
-let InternalToInt16 = <
-    T: type
-    Instructions: To16Instructions
-->
-    let toInt16: < { this: T }: Int16 > = {! this, Instructions.to16 !}
->
-
-let InternalToUInt16 = <
-    T: type
-    Instrucitons: To16Instructions
-->
-    let toUInt16: < { this: T }: UInt16 > = {! this, Instruction.to16 !}
->
-
-let To8Instructions = <*
-    let to8: Inst
-*>
-
-let InternalToInt8 = <
-    T: type
-    Instruction: To8Instructions
-->
-    let toInt8: < { this: T }: Int8 > = {! this, Instruction.to8 !}
->
-
-let InternalToUInt8 = <
-    T: type
-    Instruction: To8Instructions
-->
-    let toUInt8: < { this: T }: UInt8 > = {! this, Instruction.to8 !}
-    let toByte: < { this: T }: Byte > = {! this, Instruction.to8 !}
->
-
-let ToUnsignedInstructions = <*
-    let unsigned: Inst
-*>
-
-let InternalToUnsigned = <
-    T: type
-    UnsignedType: type
-    Instructions: ToUnsignedInstructions
-->
-    let toUnsigned: < { this: T }: UnsignedType > = {! this, Instructions.unsigned !}
->
-
-let ToSignedInstructions = <*
-    let signed: Inst
-*>
-
-let InternalToSigned = <
-    T: type
-    SignedType: type
-    Instructions: ToUnsignedInstructions
-->
-    let toSigned: < { this: T }: SignedType > = {! this, Instruction.signed !}
+    let toInt8: ConversionFunction<Type: This, Result: Int8> = { *this, Instructions.toInt8 }
+    let toUInt8: ConversionFunction<Type: This, Result: UInt8> = { *this, Instructions.toUInt8 }
+    let toByte: ConversionFunction<Type: This, Result: Byte> = { *this, Instructions.toUInt8 }
+    let toInt16: ConversionFunction<Type: This, Result: Int16> = { *this, Instructions.toInt16 }
+    let toUInt16: ConversionFunction<Type: This, Result: UInt16> = { *this, Instructions.toUInt16 }
+    let toInt32: ConversionFunction<Type: This, Result: Int32> = { *this, Instructions.toInt32 }
+    let toInt: ConversionFunction<Type: This, Result: Int> = { *this, Instructions.toInt32 }
+    let toUInt32: ConversionFunction<Type: This, Result: UInt32> = { *this, Instructions.toUInt32 }
+    let toInt64: ConversionFunction<Type: This, Result: Int64> = { *this, Instructions.toInt64 }
+    let toUInt64: ConversionFunction<Type: This, Result: Int64> = { *this, Instructions.toUInt64 }
 >
 
 let Boolean = <
-    ...InternalSized<Instructions: rt.bool>
-    ...InternalLocation<T: Boolean, Instructions: rt.bool>
-    ...InternalEquatable<T:  Boolean, Instructions: rt.bool>
+    ...LocationByInstructions<Instructions: rt.bool>
+    ...EquatableByInstructions<Instructions: rt.bool>
     ...Default<Value: false>
-    let `!`: < { this: Boolean }: Boolean > = {! this, rt.bool.not !}
+    let `!`: { this: ParameterSlot<Type: Boolean> } : Boolean = {! *this, rt.bool.not !}
 >
 
 let Int8 = <
-    ...InternalInteger<T: Int8, Instructions: rt.int8>
-    ...InternalToInt16<T: Int8, Instructions: rt.int8>
-    ...InternalToInt32<T: Int8, Instructions: rt.int8>
-    ...InternalToInt34<T: Int8, Instructions: rt.int8>
-    ...InternalToUnsigned<T: Int8, UnsignedType: UInt8, Instructions: rt.int8>
+    ...IntegerByInstructions<Instructions: rt.int8>
+    ...IntegerConversionByInstructions<Instructions: rt.int8>
     ...Default<value: 0t>
 >
 
 let Int16 = <
-    ...InternalInteger<T: Int16, Instructions: rt.int16>
-    ...InternalToInt8<T: Int16, Instructions: rt.int16>
-    ...InternalToInt32<T: Int16, Instructions: rt.int16>
-    ...InternalToInt64<T: Int16, Instrucitons: rt.int16>
-    ...InternalToUnsigned<T: Int16, UnsignedType: UInt16, Instructions: rt.int16>
+    ...IntegerByInstructions<Instructions: rt.int16>
+    ...IntegerConversionByInstructions<Instructions: rt.int16>
     ...Default<value: 0s>
 >
 
 let Int32 = <
-    ...InternalInteger<T: Int32, Instruction: rt.int32>
-    ...InternalToInt8<T: Int32, Instructions: rt.int32>
-    ...InternalToInt16<T: Int32, Instructions: rt.int32>
-    ...InternalToInt64<T: Int32, Instrucitons: rt.int32>
-    ...InternalToUnsigned<T: Int32, UnsignedType: UInt32, Instructions: rt.int32>
+    ...IntegerByInstructions<Instructions: rt.int32>
+    ...IntegerConversionByInstructions<Instructions: rt.int32>
     ...Default<value: 0>
 >
 
 let Int64 = <
-    ...InternalInteger<T: Int64, Instruction: rt.int64>
-    ...InternalToInt8<T: Int64, Instructions: rt.int64>
-    ...InternalToInt16<T: Int64, Instructions: rt.int64>
-    ...InternalToInt32<T: Int64, Instrucitons: rt.int64>
-    ...InternalToUnsigned<T: Int64, UnsignedType: UInt64, Instructions: rt.int64>
+    ...IntegerByInstructions<Instructions: rt.int64>
+    ...IntegerConversionByInstructions<Instructions: rt.int64>
     ...Default<value: 0l>
 >
 
 let UInt8 = <
-    ...InternalInteger<T: UInt8, Instructions: rt.uint8>
-    ...InternalToInt16<T: UInt8, Instructions: rt.uint8>
-    ...InternalToInt32<T: UInt8, Instructions: rt.uint8>
-    ...InternalToInt34<T: UInt8, Instructions: rt.uint8>
-    ...InternalToSigned<T: UInt8, SignedType: Int8, Instructions: rt.uint8>
+    ...IntegerByInstructions<Instructions: rt.uint8>
+    ...IntegerConversionByInstructions<Instructions: rt.uint8>
     ...Default<value: 0ut>
 >
 
 let UInt16 = <
-    ...InternalInteger<T: UInt16, Instructions: rt.uint16>
-    ...InternalToInt8<T: UInt16, Instructions: rt.uint16>
-    ...InternalToInt32<T: UInt16, Instructions: rt.uint16>
-    ...InternalToInt64<T: UInt16, Instrucitons: rt.uint16>
-    ...InternalToSigned<T: UInt16, SignedType: Int16, Instructions: rt.uint16>
+    ...IntegerByInstructions<Instructions: rt.uint16>
+    ...IntegerConversionByInstructions<Instructions: rt.uint16>
     ...Default<value: 0us>
 >
 
 let UInt32 = <
-    ...InternalInteger<T: UInt32, Instructions: rt.uint32>
-    ...InternalToInt8<T: UInt32, Instructions: rt.uint32>
-    ...InternalToInt16<T: UInt32, Instructions: rt.uint32>
-    ...InternalToInt64<T: UInt32, Instrucitons: rt.uint32>
-    ...InternalToSigned<T: UInt32, SignedType: Int32, Instructions: rt.uint32>
+    ...IntegerByInstructions<Instructions: rt.uint32>
+    ...IntegerConversionByInstructions<Instructions: rt.uint32>
     ...Default<value: 0u>
 >
 
 let UInt64 = <
-    ...InternalInteger<T: UInt64, Instructions: rt.uint64>
-    ...InternalToInt8<T: UInt64, Instructions: rt.uint64>
-    ...InternalToInt16<T: UInt64, Instructions: rt.uint64>
-    ...InternalToInt32<T: UInt64, Instrucitons: rt.uint64>
-    ...InternalToSigned<T: UInt64, SignedType: Int64, Instructions: rt.uint64>
+    ...IntegerByInstructions<Instructions: rt.uint64>
+    ...IntegerConversionByInstructions<Instructions: rt.uint64>
     ...Default<value: 0ul>
 >
 
@@ -598,58 +699,48 @@ let FloatingPointInstructions = <*
     ...ComparableInstructions
 *>
 
-let InternalFloatingPoint = <
-    T: type,
+let FloatingPointByInstructions = <
     Instructions: FloatingPointInstructions
 ->
-    ...InternalNumeric<:T, :Instructions>
-    ...InternalComparable<:T,  :Instructions>
+    ...NumericByInstructions<:Instructions>
+    ...ComparableByInstructions<:Instructions>
 >
 
 let Float32 = <
-    ...InternalFloatingPoint<T: Float32, Instructions: rt.float32>
+    ...FloatingPointByInstructions<Instructions: rt.float32>
     ...Default<value: 0.0f>
-    let toFloat64: < { this: Float32 }: Float64 > = {! this, tr.float32.to64 !}
-    let toDouble: < { this: Float32 }: Float64 > = {! this, tr.float32.to64 !}
+    let toFloat64: ConversionFunction<Type: This, Result: Float64> = {! *this, rt.float32.toFloat64 !}
 >
 
 let Float64 = <
-    ...InternalFloatingPoint<T: Float32, Instructions: rt.float32>
+    ...FloatingPointByInstructions<Instructions: rt.float64>
     ...Default<value: 0.0>
-    let toFloat32: < { this: Float64 }: Float64 > = {! this, tr.float64.to32 !}
+    let toFloat32: ConversionFunction<Type: This, Result: Float64> = {! *this, rt.float64.toFloat32 !}
 >
 
 let Byte = UInt8
 let Int = Int32
 
-let Reference = <
-    T: InternalLocation
-->
-    let `*`: < { this: This }: T > = {! this, T.`@load` !}
-    let `=`: < { this: this, value: T } > = {! this, value, T.`@store` !}
->
-
-let ArrayElement = <*
-    ...InternalSized
-    ...InternalLocation
-*>
-
 let Array = <
-    T: ArrayElement
-    Size: UInt32
+    T: Locatable
 ->
-    ...InternalSized<Size: (Size * T.`@size`)>
-
-    let size: UInt32 = Size
-    let `[]`: < { this: This }: Reference<:T> > = {!
-        infdex
-        T.`@size`
-        rt.int32.mult
-        This.`@size`
-        rt.index.validate
-        rt.addr.effective(value: this)
-        rt.int32.add
-    !}
+    let elements = FieldSlot<Type: HeapSlot<Type: T>>
+    let size = FieldSlot<Type: Offset>
+    let `@ctor`: {
+        this: Location<Type: This>,
+        address: ParameterSlot<Type: Address>
+        size: ParameterSlot<Type: Offset>
+    } = {
+        (*this).elements.address = *address
+        (*this).size = *size
+    }
+    let `[]`: {
+        this: ParameterSlot<Type: This>
+        index: ParamterSlot<Type: Offset>
+    }: Location<:Type> = {
+        if (*index < 0 || *index >= *(*this).size) { panic() }
+        return (*this).elements[*index]
+    }
 >
 
 <

--- a/examples/raytrace.dg
+++ b/examples/raytrace.dg
@@ -1,0 +1,177 @@
+...Dyego
+
+let Vector = <
+    val x: Double
+    val y: Double
+    val z: Double
+
+    let `*`: { this: This, right as scale: Double }: Vector = { 
+        return [x: this.x * scale, y: this.y * scale, z: this.z * scale] 
+    }
+    let `+`: { this: This, right as other: Vector }: Vector = {
+        return [x: this.x + other.x, y: this.y + other.y, z: this.z + other.z ]
+    }
+    let `-`: { this: This, right as other: Vector }: Vector = {
+        return [x: this.x - other.x, y: this.y - other.y, z: this.z - other.z ]
+    }
+    let dot: { this: This, right as other: Vector }: Double = {
+        return this.x * other.x + this.y * other.y + this.z * other.z
+    }
+    let magnitude: { this: This }: Double = {
+        return (this dot this).sqrt()
+    }
+    let normalize: { this: This }: Double = {
+        return this * (1.0 / this.magnitude())
+    }
+>
+
+let Ray = <
+    val origin: Vector
+    val direction: Vector
+
+    let intersectsWith: { this: This, sphere: Sphere }: Double? = {
+        val l = sphere.center - this.origin
+        val tca = l dot this.direction
+        if (tca < 0.0) {
+            return null
+        }
+        val d2 = (l dot l) - tca * tca
+        val r2 = sphere.radius * sphere.radius
+        if (d2 > r2) {
+            return null
+        }
+        val thc = (r2 - d2).sqrt()
+        val t0 = tca - tch
+        val (t0 > 1000.0) {
+            return null
+        }
+        return t0
+    }
+>
+
+let Color = <
+    val r: Double
+    val g: Double
+    val b: Double
+
+    let `*`: { this: This, right as scale: Double }: Color = {
+        return [r: this.r * scale, g: this.g * scale, b: this.b * scale ]
+    }
+    let `+`: { this: This, right as other: Color }: Color = {
+        return [r: this.r + other.r, g: this.g + other.g, b: this.b + other.b ]
+    }
+    let intensity: { this: This }: Double = {
+        return this.r + this.g + this.b
+    }
+>
+
+val white: Color = [r: 1.0, g: 1.0, b: 1.0]
+val red: Color = [r: 1.0, g: 0.0, b: 0.0 ]
+val green: Color = [r: 0.0, g: 1.0, b: 0.0 ]
+val blue: Color = [r: 0.0, g: 0.0, b: 1.0 ]
+
+let Sphere = <
+    val center: Vector
+    val radius: Double
+    val color: Color
+
+    let normalize: { this: This, vector: Vector }: Vector = {
+        return (this.center - vector).normalize()
+    }
+>
+
+let Light = <
+    position: Vector
+    color: Color
+>
+
+val light1: Light = [position: [x: 0.7, y: -1.0, z: 1.7], color: white]
+val lut: String[] = [".", "-", "+", "X", "M"]
+val w: Int32 = 80
+val h: Int32 = 40
+
+val spheres: { t: Double }: Sphere[] = {
+    return [
+        [   center: [x: -1.0, y: 1.0 - t/10.0, z: 3.0]]
+            radius: 0.3
+            color: red
+        ]
+        [   center: [x: 0.0, y: 1.0 - t/10.0, z: 3.0 - t/4.0]]
+            radius: 0.8
+            color: green
+        ]
+        [   center: [x: 1.0, y: 0.0, z: 1.5]]
+            radius: 0.8
+            color: blue
+        ]
+    ]
+}
+
+let render: { t: Double } = {
+    var y: Int32 = 0
+    val fw: Double = w.toDouble()
+    val fh: Double = h.toDouble()
+    val scene = spheres(:t)
+    while (y < h) {
+        val fy = y.toDouble()
+        var x = 0
+        while (x < w) {
+            val fx = x.toDouble()
+            val ray: Ray = [<Ray>
+                origin: [x: 1.5, y: 1.7, z: -5.5]
+                direction: [x: (fx - fw)/3.0/fw, y: (fy - fh)/3.0/fh, z: 1.0]
+            ].normalize()
+            
+            var i = 0
+            let Hit = < sphere: Sphere, tval: Double > 
+            var hit: Hit? = null
+            while (i < scene.length) {
+                val sphere = spheres[i]
+                val tval = ray.intersectsWith(:sphere)
+                when (tval) {
+                    is Double -> {
+                        hit = [:sphere, :tval]
+                    }
+                }
+            }
+            when (hit) {
+                is Hit -> {
+                    print(text: pixel(:ray, :hit.sphere, :hit.tval))
+                }
+                else -> {
+                    print(text: " ")
+                }
+            }
+            x = x + 1
+        }
+        println(text: "\n")
+        y = y + 1
+    }
+}
+
+let pixel: { ray: Ray, sphere: Vector, tval: Double }: String = {
+    val p1: Vector = ray.origin + ray.direction * tval
+    val color: Color = diffuseShading(:p1, :sphere, light: light1)
+    val intensity: Double = color.intensity() / 3.0
+    return lut[(intensity * lut.length().toDouble()).floor()]
+}
+
+let clamp: { this: Double, min: Double, max: Double }: Double = {
+    return when {
+        this < min -> min
+        this > max -> max
+        else -> this
+    }
+}
+
+let diffuseShading: {p1: Vector, sphere: Sphere, light: Light}: Color = {
+    val n: Vector = sphere.normalize()
+    val lam: Double = ((light.position - p1).normalize() dot n).clamp(0.0, 1.0)
+    return light.color * lam * 0.5  + sphere.color * 0.3
+}
+
+var t: Double = 0.0
+while (t < 1.0) {
+    render(:t)
+    t = t + 0.3
+}

--- a/examples/raytrace.dg0
+++ b/examples/raytrace.dg0
@@ -1,0 +1,168 @@
+...Dyego
+
+let Vector = <
+    let x = FieldSlot<Double, 0, 0>
+    let y = FieldSlot<Double, Double.`@locals`.length, Double.`@size`>
+    let z = FieldSlot<Double, Double.`@locals`.length + * 2, Double.`@size` * 2>
+
+    let `@ctor`: { 
+        this: Location<This>
+        x: ParameterSlot<Double, 0>
+        y: ParameterSlot<Double, Double.locals.length>
+        z: ParameterSlot<Double, Double.locals.length * 2> 
+    }: Vector = {
+        let result = LocalSlot<Vector, 0>
+        result.x = *x
+        result.y = *y
+        result.z = *z
+        return *result
+    }
+
+    let `@size` = Double.`@size` * 3
+    let `@locals` = Double.`@locals` * 3
+    let `@load.global`: { 
+        address: ParameterSlot<Address, 0> 
+    }: This = {
+        return [<This>
+            x: x.`@load.global`(*address)
+            y: y.`@load,global`(*address)
+            z: z.`@load.global(*address)
+        ]
+    }
+    let `@store.global`: { 
+        this: ParameterSlot<This, 0>
+        address: ParameterSlot<Address, This.locals.size> 
+    } = {
+        x.`@store.global`(*this.x, *address)
+        y.`@store.global`(*this.y, *address)
+        z.`@store.global`(*this.z, *address)
+    }
+    let `@load.local`: { 
+        index: ParameterSlot<Index, 0> 
+    }: This = {
+        return [<This>
+            x: x.`@load.local`(*index)
+            y: y.`@load,local`(*index)
+            z: z.`@load.local(*index)
+        ]
+    }
+    let `@store.local`: { 
+        this: ParameterSlot<This, 0>, 
+        index: ParameterSlot<Index, This.locals.size> 
+    } = {
+        x.`@store.local`(*this.x, *index)
+        y.`@store.local`(*this.y, *index)
+        z.`@store.local`(*this.z, *index)
+    }
+    let `@load.param`: { 
+        index: ParameterSlot<Index, 0> 
+    }: This = {
+        return [<This>
+            x: x.`@load.param`(*index)
+            y: y.`@load,param`(*index)
+            z: z.`@load.param(*index)
+        ]
+    }
+
+    let `*`: { 
+        this: ParameterSlot<This, 0>, 
+        scale: ParameterSlot<Double, This.locals.length> 
+    }: Vector = {
+        return [<This>
+            x: *this.x * *scale
+            y: *this.y * *scale
+            z: *this.z * *scale
+        ]
+    }
+    let `+`: { 
+        this: ParameterSlot<This, 0>, 
+        other: ParameterSlot<Vector, This.locals.length> 
+    }: Vector = {
+        return `Vector$ctor`(
+            x: *this.x * *other.x
+            y: *this.y * *other.y
+            z: *this.z * *other.z
+        )
+    }
+    let `-`: { 
+        this: ParameterSlot<This, 0>, 
+        other: ParameterSlot<Vector, This.locals.length>
+    }: Vector = {
+        return [x: *this.x - *other.x, y: *this.y - *other.y, z: *this.z - *other.z ]
+    }
+    let dot: { 
+        this: ParameterSlot<This, 0>, 
+        other: ParameterSlot<Vector, This.locals.length> 
+    }: Double = {
+        return *this.x * *other.x + *this.y * *other.y + *this.z * *other.z
+    }
+    let magnitude: { 
+        this: ParameterSlot<This, 0> 
+    }: Double = {
+        return (*this dot *this).sqrt()
+    }
+    let normalize: { this: ParameterSlot<This> }: Double = {
+        return *this * (1.0 / (*this).magnitude())
+    }
+>: Locatable
+
+let Ray = <
+    let origin = FieldSlot<Vector, 0, 0>
+    let direction = FieldSlot<Vector, Vector.locals.length, Vector.`@size`> 
+    let `@ctor`: { 
+        origin: ParameterSlot<Vector, 0>, 
+        direction: ParameterSlot<Vector, Vector.locals.length> 
+    }: Ray = {
+        let result = LocalSlot<Ray, 0>
+        result.origin = *origin
+        result.direciton = *direction
+        return *result
+    }
+    let intersectsWith: { 
+        this: ParameterSlot<This, 0>, 
+        sphere: ParameterSlot<Sphere, This.locals.length>
+    }: Double? = {
+        let l = LocalSlot<
+            Vector
+            0
+        >
+        l = *sphere.center - *this.origin
+        let tca = LocalSlot<
+            Double
+            Vector.locals.length
+        >
+        tca = *l dot *this.direction
+        if (*tca < 0.0) {
+            return null
+        }
+        let d2 = LocalSlot<
+            Double
+            Vector.locals.length + Double.locals.length
+        >
+        d2 = (*l dot *l) - *tca * *tca
+        let r2 = LocalSlot<
+            Double
+            Vector.locals.length + Double.locals.length * 2
+        >
+        r2 = *sphere.radius * *sphere.radius 
+        if (*d2 > *r2) {
+            return null
+        }
+        let thc = LocalSlot<
+            Double
+            Vector.locals.length + Double.locals.length * 3
+        >
+        tch = (*r2 - *d2).sqrt()
+        let t0 = LocalSlot<
+            Double
+            Vector.locals.length + Double.locals.length * 4
+        >
+        t0 = *tca - *tch
+
+        val (*t0 > 1000.0) {
+            return null
+        }
+        return *t0
+    }
+>
+

--- a/src/ast.spec.ts
+++ b/src/ast.spec.ts
@@ -65,6 +65,13 @@ describe("ast", () => {
             expect(n.typeArguments).toEqual([])
             ch(n).toEqual([t])
         })
+        it("can create an index", () => {
+            const n = builder.Index(t, v)
+            expect(n.kind).toBe(ElementKind.Index)
+            expect(n.target).toBe(t)
+            expect(n.index).toBe(v)
+            ch(n).toEqual([t, v])
+        })
         it("can create a named argument", () => {
             const n = builder.NamedArgument(t, v)
             expect(n.kind).toBe(ElementKind.NamedArgument)
@@ -73,15 +80,17 @@ describe("ast", () => {
             ch(n).toEqual([t, v])
         })
         it("can create a value literal", () => {
-            const n = builder.ValueLiteral([])
+            const n = builder.ValueLiteral([], undefined)
             expect(n.kind).toBe(ElementKind.ValueLiteral)
             expect(n.members).toEqual([])
+            expect(n.qualifier).toEqual(undefined)
             ch(n).toEqual([])
         })
         it("can create an entity literal", () => {
-            const n = builder.EntityLiteral([])
+            const n = builder.EntityLiteral([], undefined)
             expect(n.kind).toBe(ElementKind.EntityLiteral)
             expect(n.members).toEqual([])
+            expect(n.qualifier).toEqual(undefined)
             ch(n).toEqual([])
         })
         it("can create an value array literal", () => {
@@ -201,9 +210,16 @@ describe("ast", () => {
             expect(n.constraint).toBe(v)
             ch(n).toEqual([v])
         })
-        it("can create an invoke member", () => {
-            const n = builder.InvokeMember([t], [v], v)
-            expect(n.kind).toBe(ElementKind.InvokeMember)
+        it("can create a call signature", () => {
+            const n = builder.CallSignature([t], [v], v)
+            expect(n.kind).toBe(ElementKind.CallSignature)
+            expect(n.typeParameters).toEqual([t])
+            expect(n.parameters).toEqual([v])
+            expect(n.result).toEqual(v)
+        })
+        it("can create an intrinsic call signature", () => {
+            const n = builder.IntrinsicCallSignature([t], [v], v)
+            expect(n.kind).toBe(ElementKind.IntrinsicCallSignature)
             expect(n.typeParameters).toEqual([t])
             expect(n.parameters).toEqual([v])
             expect(n.result).toEqual(v)
@@ -220,6 +236,12 @@ describe("ast", () => {
             expect(n.kind).toBe(ElementKind.VocabularyLiteral)
             expect(n.members).toEqual([])
             ch(n).toEqual([])
+        })
+        it("can create a symbol literal", () => {
+            const n = builder.SymbolLiteral([v])
+            expect(n.kind).toBe(ElementKind.SymbolLiteral)
+            expect(n.values).toEqual([v])
+            ch(n).toEqual([v])
         })
         it("can create a array type", () => {
             const n = builder.ArrayType(t)

--- a/src/parser.spec.ts
+++ b/src/parser.spec.ts
@@ -168,25 +168,30 @@ describe("Parser", () => {
         it("can use a type literal to export", () => {
             p("< let a = a, let b = b, >")
         })
-        it("can have a simple invoke member", () => {
-            t("< { } >")
-        })
-        it("can parse an invoke member with parameters", () => {
-            t("< { a: Int, b: Int } >")
-        })
-        it("can have an invoke member with a result", () => {
-            t("< { }: Int >")
-            t("< { a: Int, b: Int}: Int >")
-        })
-        it("can have an invoke member with a type parameter", () => {
-            t("< { T -> a: T }: T >")
-            t("< { T, V: Int -> a: T }: T >")
-        })
         it("can validate a type literal with a constraint", () => {
             t("< let a: Int = 1 > : Constraint")
         })
         function t(source: string) {
             return p(`let a = ${source}`)
+        }
+    })
+    describe("singatures", () => {
+        it("can have a simple signature", () => {
+            s("{ }")
+        })
+        it("can parse an signature with parameters", () => {
+            s("{ a: Int, b: Int }")
+        })
+        it("can have an signature with a result", () => {
+            s("{ }: Int")
+            s("{ a: Int, b: Int}: Int")
+        })
+        it("can have an signature with a type parameter", () => {
+            s("{ T -> a: T }: T")
+            s("{ T, V: Int -> a: T }: T")
+        })
+        function s(source: string) {
+            return p(`let a: ${source} = { }`)
         }
     })
     describe("mutable value type literal", () => {
@@ -207,9 +212,6 @@ describe("Parser", () => {
         })
         it("can use a type literal to export", () => {
             p("<! let a = a, let b = b, !>")
-        })
-        it("can have a simple invoke member", () => {
-            t("<! { } !>")
         })
         it("can validate a type literal with a constraint", () => {
             t("<! let a: Int = 1 !> : Constraint")

--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -102,6 +102,7 @@ export class Scanner {
                 case Code.plus:
                 case Code.bar:
                 case Code.dash:
+                case Code.dollar:
                 case Code.star:
                 case Code.slash:
                 case Code.percent:
@@ -155,6 +156,14 @@ export class Scanner {
                             if (!symbolExtender(src[offset])) {
                                 this.psuedo = PseudoToken.Sub
                                 this.value = "-"
+                                break loop
+                            }
+                            break
+                        case Code.dollar:
+                            if (src[offset] == Code.gt && !symbolExtender(src[offset + 1])) {
+                                offset++
+                                this.psuedo = PseudoToken.DollarGreaterThan
+                                this.value = "$>"
                                 break loop
                             }
                             break
@@ -263,6 +272,7 @@ export class Scanner {
                                         this.value = "<!"
                                         break loop
                                     }
+                                    break
                                 case Code.bar:
                                     offset++
                                     result = Token.VocabStart
@@ -273,6 +283,14 @@ export class Scanner {
                                     result = Token.ConstraintStart
                                     this.value = "<*"
                                     break loop
+                                case Code.dollar:
+                                    if (!symbolExtender(src[offset + 1])) {
+                                        offset++
+                                        this.psuedo = PseudoToken.LessThanDollar
+                                        this.value = "<$"
+                                        break loop
+                                    }
+                                    break
                             }
                             if (!symbolExtender(src[offset])) {
                                 this.psuedo = PseudoToken.LessThan
@@ -332,7 +350,6 @@ export class Scanner {
                     case Code.dash:
                     case Code.at:
                     case Code.sharp:
-                    case Code.dollar:
                     case Code.hat:
                         symbolLoop: while(true) {
                             const last = offset

--- a/src/tokens.ts
+++ b/src/tokens.ts
@@ -111,6 +111,8 @@ export const enum PseudoToken {
     LessThanEqual, // <=
     LessThanBang, // <!
     BangGreaterThan, // !>
+    LessThanDollar, // <$
+    DollarGreaterThan, // $>
     Question, // ?
     Arrow, // ->
     Range, // ..
@@ -159,6 +161,8 @@ export function nameOfPseudoToken(pseudo: PseudoToken): string {
         case PseudoToken.LessThanEqual: return "<="
         case PseudoToken.LessThanBang: return "<!"
         case PseudoToken.BangGreaterThan: return "!>"
+        case PseudoToken.LessThanDollar: return "<$"
+        case PseudoToken.DollarGreaterThan: return "$>"
         case PseudoToken.Question: return "?"
         case PseudoToken.Arrow: return "->"
         case PseudoToken.Range: return ".."

--- a/src/types/enter.spec.ts
+++ b/src/types/enter.spec.ts
@@ -51,7 +51,7 @@ describe("type parameters", () => {
 describe("multiple files", () => {
     it("can enter multiple files", () => {
         const context = e({
-            "src" {
+            "src": {
                 "file1.dg": "let a = < >",
                 "file2.dg": "let b = < >"
             }


### PR DESCRIPTION
Removed higher level constructs as well as focus more on physcial
constructs. For example, removed all notion of `var` and `val` which
can be created as a transform into this lower level constructs. In
other words if a construct can be represented as a lower level construct
it should be removed from the language and implemented as a transform.

This is not complete yet as and the AST contains higher level nodes.
I have yet to decide if these should be removed or isolated.